### PR TITLE
use legacy rest-client NotFound exception

### DIFF
--- a/lib/smart_proxy_monitoring_icinga2/monitoring_icinga2_main.rb
+++ b/lib/smart_proxy_monitoring_icinga2/monitoring_icinga2_main.rb
@@ -134,7 +134,7 @@ module Proxy::Monitoring::Icinga2
       result
     rescue JSON::ParserError => e
       raise Proxy::Monitoring::Error.new("Icinga server at #{::Proxy::Monitoring::Icinga2::Plugin.settings.server} returned invalid JSON: '#{e.message}'")
-    rescue RestClient::NotFound => e
+    rescue RestClient::ResourceNotFound => e
       raise Proxy::Monitoring::NotFound.new("Icinga server at #{::Proxy::Monitoring::Icinga2::Plugin.settings.server} returned: #{e.message}.")
     rescue RestClient::Exception => e
       raise Proxy::Monitoring::Error.new("Icinga server at #{::Proxy::Monitoring::Icinga2::Plugin.settings.server} returned an error: '#{e.response}'")

--- a/lib/smart_proxy_monitoring_icingadirector/director_client.rb
+++ b/lib/smart_proxy_monitoring_icingadirector/director_client.rb
@@ -23,7 +23,7 @@ module ::Proxy::Monitoring::IcingaDirector
     def get(url)
       logger.debug "IcingaDirector: GET request to #{url}"
       client(url).get.body
-    rescue RestClient::NotFound
+    rescue RestClient::ResourceNotFound
       raise Proxy::Monitoring::NotFound.new("Icinga Director returned not found for #{url}.")
     end
 
@@ -40,7 +40,7 @@ module ::Proxy::Monitoring::IcingaDirector
     def delete(url)
       logger.debug "IcingaDirector: DELETE request to #{url}"
       client(url).delete.body
-    rescue RestClient::NotFound
+    rescue RestClient::ResourceNotFound
       raise Proxy::Monitoring::NotFound.new("Icinga Director returned not found for #{url}.")
     end
 


### PR DESCRIPTION
Older rest-client versions, e.g. 1.8.0 use RestClient::ResourceNotFound
instead of RestClient::NotFound. The former is still supported with
newer versions.

Fixes #6.