### PR TITLE
Support setting downtime for host and all services

### DIFF
--- a/lib/smart_proxy_monitoring/monitoring_api.rb
+++ b/lib/smart_proxy_monitoring/monitoring_api.rb
@@ -58,11 +58,14 @@ module Proxy::Monitoring
       comment = params[:comment] || 'triggered by foreman'
       start_time = params[:start_time] || Time.now.to_i
       end_time = params[:end_time] || (Time.now.to_i + (24 * 3600))
+      all_services = params[:all_services]
 
       log_provider_errors do
         validate_dns_name!(host)
         host = strip_domain(host)
 
+        server.set_downtime_host(host, author, comment, start_time, end_time, all_services: all_services)
+      rescue ArgumentError
         server.set_downtime_host(host, author, comment, start_time, end_time)
       end
     end

--- a/lib/smart_proxy_monitoring_icinga2/monitoring_icinga2_main.rb
+++ b/lib/smart_proxy_monitoring_icinga2/monitoring_icinga2_main.rb
@@ -58,7 +58,7 @@ module Proxy::Monitoring::Icinga2
       result.to_json
     end
 
-    def set_downtime_host(host, author, comment, start_time, end_time)
+    def set_downtime_host(host, author, comment, start_time, end_time, all_services: nil, **)
       request_url = "/actions/schedule-downtime?type=Host&filter=#{uri_encode_filter("host.name==\"#{host}\"")}"
       data = {
         'author' => author,
@@ -67,6 +67,7 @@ module Proxy::Monitoring::Icinga2
         'end_time' => end_time,
         'duration' => 1000
       }
+      data['all_services'] = all_services unless all_services.nil?
 
       result = with_errorhandling("Set downtime on #{host}") do
         Icinga2Client.post(request_url, data.to_json)

--- a/test/monitoring/monitoring_api_test.rb
+++ b/test/monitoring/monitoring_api_test.rb
@@ -9,6 +9,7 @@ class MonitoringApiTest < Test::Unit::TestCase
   include Rack::Test::Methods
 
   class MonitoringApiTestProvider
+    # Also tests fallback for old #set_downtime_host without named arguments
     def set_downtime_host(host, author, comment, start_time, end_time); end
 
     def remove_downtime_host(host, author, comment); end

--- a/test/monitoring_icinga2/monitoring_icinga2_provider_test.rb
+++ b/test/monitoring_icinga2/monitoring_icinga2_provider_test.rb
@@ -117,6 +117,14 @@ class MonitoringIcinga2ProviderTest < Test::Unit::TestCase
     @provider.set_downtime_host('xyz.example.com', 'Foreman', 'Downtime by Foreman', '1491819090', '1491819095')
   end
 
+  def test_set_downtime_host_all_services
+    icinga_result = '{"results":[{"code":200.0,"legacy_id":2.0,"name":"xyz.example.com!xyz.example.com-1491819090-1","status":"Successfully scheduled downtime \'xyz.example.com!xyz.example.com-1491819090-1\' for object \'xyz.example.com\'."}]}'
+    stub_request(:post, "https://localhost:5665/v1/actions/schedule-downtime?filter=host.name==%22xyz.example.com%22&type=Host").
+      with(:body => "{\"author\":\"Foreman\",\"comment\":\"Downtime by Foreman\",\"start_time\":\"1491819090\",\"end_time\":\"1491819095\",\"duration\":1000,\"all_services\":true}").
+      to_return(:status => 200, :body => icinga_result)
+    @provider.set_downtime_host('xyz.example.com', 'Foreman', 'Downtime by Foreman', '1491819090', '1491819095', all_services: true)
+  end
+
   def test_remove_downtime_host
     icinga_result = '{"results":[{"code":200.0,"status":"Successfully removed all downtimes for object \'xyz.example.com\'."}]}'
     stub_request(:post, "https://localhost:5665/v1/actions/remove-downtime?author==%22Foreman%22&comment=%22Downtime%20by%20Foreman%22&filter=host.name==%22xyz.example.com%22&type=Host").


### PR DESCRIPTION
As this modifies the `Provider#set_host_downtime` method, I included an automatic fallback to the old one, for if anyone has made their own plugin on top of the smart-proxy monitoring API