### PR TITLE
Send to API v2 endpoint for Foreman 3.1+ compatibility

### DIFF
--- a/lib/smart_proxy_monitoring_icinga2/icinga2_result_uploader.rb
+++ b/lib/smart_proxy_monitoring_icinga2/icinga2_result_uploader.rb
@@ -3,7 +3,7 @@ require 'thread'
 module ::Proxy::Monitoring::Icinga2
   class MonitoringResult < Proxy::HttpRequest::ForemanRequest
     def push_result(result)
-      send_request(request_factory.create_post('api/monitoring_results', result))
+      send_request(request_factory.create_post('api/v2/monitoring_results', result))
     end
   end
 


### PR DESCRIPTION
The `/api/monitoring_results` endpoint no longer exists in Foreman 3.1+. Sending it directly to `/api/v2/monitoring_results` does work and I expect it to also work on older Foreman versions.