### PR TITLE
Send downtime parameters via the body

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,10 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-Lint/UriEscapeUnescape:
-  Exclude:
-    - 'lib/smart_proxy_monitoring_icinga2/monitoring_icinga2_main.rb'
-
 # Configuration parameters: MinNameLength, AllowNamesEndingInNumbers, AllowedNames, ForbiddenNames.
 # AllowedNames: at, by, db, id, in, io, ip, of, on, os, pp, to
 Naming/MethodParameterName:

--- a/lib/smart_proxy_monitoring_icinga2/monitoring_icinga2_main.rb
+++ b/lib/smart_proxy_monitoring_icinga2/monitoring_icinga2_main.rb
@@ -49,8 +49,13 @@ module Proxy::Monitoring::Icinga2
     end
 
     def remove_downtime_host(host, author, comment)
-      request_url = "/actions/remove-downtime?type=Host&filter=#{uri_encode_filter("host.name==\"#{host}\"\&\&author==\"#{author}\"\&\&comment=\"#{comment}\"")}"
-      data = {}
+      request_url = "/actions/remove-downtime"
+      data = {
+        type: 'Host',
+        filter: "host.name==\"#{host}\"",
+        author: author,
+        comment: comment,
+      }
 
       result = with_errorhandling("Remove downtime from #{host}") do
         Icinga2Client.post(request_url, data.to_json)
@@ -59,8 +64,10 @@ module Proxy::Monitoring::Icinga2
     end
 
     def set_downtime_host(host, author, comment, start_time, end_time, all_services: nil, **)
-      request_url = "/actions/schedule-downtime?type=Host&filter=#{uri_encode_filter("host.name==\"#{host}\"")}"
+      request_url = "/actions/schedule-downtime"
       data = {
+        'type' => 'Host',
+        'filter' => "host.name==\"#{host}\"",
         'author' => author,
         'comment' => comment,
         'start_time' => start_time,
@@ -76,10 +83,6 @@ module Proxy::Monitoring::Icinga2
     end
 
     private
-
-    def uri_encode_filter(filter)
-      URI.encode(filter)
-    end
 
     def host_attributes(host, data)
       attributes = {}

--- a/smart_proxy_monitoring.gemspec
+++ b/smart_proxy_monitoring.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'json'
   s.add_dependency 'rest-client'
 
-  s.required_ruby_version = '>= 2.5', '< 3'
+  s.required_ruby_version = '>= 2.5', '< 4'
 end

--- a/test/monitoring_icinga2/monitoring_icinga2_provider_test.rb
+++ b/test/monitoring_icinga2/monitoring_icinga2_provider_test.rb
@@ -111,24 +111,24 @@ class MonitoringIcinga2ProviderTest < Test::Unit::TestCase
 
   def test_set_downtime_host
     icinga_result = '{"results":[{"code":200.0,"legacy_id":2.0,"name":"xyz.example.com!xyz.example.com-1491819090-1","status":"Successfully scheduled downtime \'xyz.example.com!xyz.example.com-1491819090-1\' for object \'xyz.example.com\'."}]}'
-    stub_request(:post, "https://localhost:5665/v1/actions/schedule-downtime?filter=host.name==%22xyz.example.com%22&type=Host").
-      with(:body => '{"author":"Foreman","comment":"Downtime by Foreman","start_time":"1491819090","end_time":"1491819095","duration":1000}').
+    stub_request(:post, "https://localhost:5665/v1/actions/schedule-downtime").
+      with(:body => '{"type":"Host","filter":"host.name==\"xyz.example.com\"","author":"Foreman","comment":"Downtime by Foreman","start_time":"1491819090","end_time":"1491819095","duration":1000}').
       to_return(:status => 200, :body => icinga_result)
     @provider.set_downtime_host('xyz.example.com', 'Foreman', 'Downtime by Foreman', '1491819090', '1491819095')
   end
 
   def test_set_downtime_host_all_services
     icinga_result = '{"results":[{"code":200.0,"legacy_id":2.0,"name":"xyz.example.com!xyz.example.com-1491819090-1","status":"Successfully scheduled downtime \'xyz.example.com!xyz.example.com-1491819090-1\' for object \'xyz.example.com\'."}]}'
-    stub_request(:post, "https://localhost:5665/v1/actions/schedule-downtime?filter=host.name==%22xyz.example.com%22&type=Host").
-      with(:body => '{"author":"Foreman","comment":"Downtime by Foreman","start_time":"1491819090","end_time":"1491819095","duration":1000,"all_services":true}').
+    stub_request(:post, "https://localhost:5665/v1/actions/schedule-downtime").
+      with(:body => '{"type":"Host","filter":"host.name==\"xyz.example.com\"","author":"Foreman","comment":"Downtime by Foreman","start_time":"1491819090","end_time":"1491819095","duration":1000,"all_services":true}').
       to_return(:status => 200, :body => icinga_result)
     @provider.set_downtime_host('xyz.example.com', 'Foreman', 'Downtime by Foreman', '1491819090', '1491819095', all_services: true)
   end
 
   def test_remove_downtime_host
     icinga_result = '{"results":[{"code":200.0,"status":"Successfully removed all downtimes for object \'xyz.example.com\'."}]}'
-    stub_request(:post, "https://localhost:5665/v1/actions/remove-downtime?author==%22Foreman%22&comment=%22Downtime%20by%20Foreman%22&filter=host.name==%22xyz.example.com%22&type=Host").
-      with(:body => "{}").
+    stub_request(:post, "https://localhost:5665/v1/actions/remove-downtime").
+      with(:body => '{"type":"Host","filter":"host.name==\"xyz.example.com\"","author":"Foreman","comment":"Downtime by Foreman"}').
       to_return(:status => 200, :body => icinga_result)
     @provider.remove_downtime_host('xyz.example.com', 'Foreman', 'Downtime by Foreman')
   end

--- a/test/monitoring_icinga2/monitoring_icinga2_provider_test.rb
+++ b/test/monitoring_icinga2/monitoring_icinga2_provider_test.rb
@@ -75,7 +75,7 @@ class MonitoringIcinga2ProviderTest < Test::Unit::TestCase
     icinga_result = '{"results":[{"code":200.0,"status":"Object was created"}]}'
     stub_request(:put, "https://localhost:5665/v1/objects/hosts/xyz.example.com").
       with(
-        :body => "{\"templates\":[\"foreman-host\"],\"attrs\":{\"address\":\"1.1.1.1\",\"address6\":\"2001:db8::1\"}}"
+        :body => '{"templates":["foreman-host"],"attrs":{"address":"1.1.1.1","address6":"2001:db8::1"}}'
     ).
     to_return(:status => 200, :body => icinga_result)
 
@@ -90,7 +90,7 @@ class MonitoringIcinga2ProviderTest < Test::Unit::TestCase
     icinga_result = '{"results":[{"code":200.0,"name":"xyz.example.com","status":"Attributes updated.","type":"Host"}]}'
     stub_request(:post, "https://localhost:5665/v1/objects/hosts/xyz.example.com").
       with(
-        :body => "{\"templates\":[\"foreman-host\"],\"attrs\":{\"address\":\"1.1.1.1\",\"address6\":\"2001:db8::1\"}}"
+        :body => '{"templates":["foreman-host"],"attrs":{"address":"1.1.1.1","address6":"2001:db8::1"}}'
     ).
     to_return(:status => 200, :body => icinga_result)
 
@@ -112,7 +112,7 @@ class MonitoringIcinga2ProviderTest < Test::Unit::TestCase
   def test_set_downtime_host
     icinga_result = '{"results":[{"code":200.0,"legacy_id":2.0,"name":"xyz.example.com!xyz.example.com-1491819090-1","status":"Successfully scheduled downtime \'xyz.example.com!xyz.example.com-1491819090-1\' for object \'xyz.example.com\'."}]}'
     stub_request(:post, "https://localhost:5665/v1/actions/schedule-downtime?filter=host.name==%22xyz.example.com%22&type=Host").
-      with(:body => "{\"author\":\"Foreman\",\"comment\":\"Downtime by Foreman\",\"start_time\":\"1491819090\",\"end_time\":\"1491819095\",\"duration\":1000}").
+      with(:body => '{"author":"Foreman","comment":"Downtime by Foreman","start_time":"1491819090","end_time":"1491819095","duration":1000}').
       to_return(:status => 200, :body => icinga_result)
     @provider.set_downtime_host('xyz.example.com', 'Foreman', 'Downtime by Foreman', '1491819090', '1491819095')
   end
@@ -120,7 +120,7 @@ class MonitoringIcinga2ProviderTest < Test::Unit::TestCase
   def test_set_downtime_host_all_services
     icinga_result = '{"results":[{"code":200.0,"legacy_id":2.0,"name":"xyz.example.com!xyz.example.com-1491819090-1","status":"Successfully scheduled downtime \'xyz.example.com!xyz.example.com-1491819090-1\' for object \'xyz.example.com\'."}]}'
     stub_request(:post, "https://localhost:5665/v1/actions/schedule-downtime?filter=host.name==%22xyz.example.com%22&type=Host").
-      with(:body => "{\"author\":\"Foreman\",\"comment\":\"Downtime by Foreman\",\"start_time\":\"1491819090\",\"end_time\":\"1491819095\",\"duration\":1000,\"all_services\":true}").
+      with(:body => '{"author":"Foreman","comment":"Downtime by Foreman","start_time":"1491819090","end_time":"1491819095","duration":1000,"all_services":true}').
       to_return(:status => 200, :body => icinga_result)
     @provider.set_downtime_host('xyz.example.com', 'Foreman', 'Downtime by Foreman', '1491819090', '1491819095', all_services: true)
   end


### PR DESCRIPTION
This avoids needing to URL encode the parameters and simplifies the code. This removes the need for URI.encode, which is removed in Ruby 3.