### PR TITLE
Upgrade to Ruby 3.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
   Exclude:
     - 'test/**/*'
     - 'vendor/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,6 @@ group :test do
   gem 'rack-test'
   gem 'rake'
   gem 'smart_proxy', github: 'theforeman/smart-proxy', branch: 'develop'
-  gem 'test-unit'
+  gem 'test-unit', '~> 3'
   gem 'webmock'
 end

--- a/smart_proxy_monitoring.gemspec
+++ b/smart_proxy_monitoring.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'json'
   s.add_dependency 'rest-client'
 
-  s.required_ruby_version = '>= 2.5', '< 4'
+  s.required_ruby_version = '>= 2.7', '< 4'
 end

--- a/test/monitoring_icinga2/monitoring_icinga2_provider_test.rb
+++ b/test/monitoring_icinga2/monitoring_icinga2_provider_test.rb
@@ -127,7 +127,7 @@ class MonitoringIcinga2ProviderTest < Test::Unit::TestCase
 
   def test_remove_downtime_host
     icinga_result = '{"results":[{"code":200.0,"status":"Successfully removed all downtimes for object \'xyz.example.com\'."}]}'
-    stub_request(:post, "https://localhost:5665/v1/actions/remove-downtime").
+     stub_request(:post, "https://localhost:5665/v1/actions/remove-downtime").
       with(:body => '{"type":"Host","filter":"host.name==\"xyz.example.com\"","author":"Foreman","comment":"Downtime by Foreman"}').
       to_return(:status => 200, :body => icinga_result)
     @provider.remove_downtime_host('xyz.example.com', 'Foreman', 'Downtime by Foreman')

--- a/test/monitoring_icinga2/monitoring_icinga2_provider_test.rb
+++ b/test/monitoring_icinga2/monitoring_icinga2_provider_test.rb
@@ -127,7 +127,7 @@ class MonitoringIcinga2ProviderTest < Test::Unit::TestCase
 
   def test_remove_downtime_host
     icinga_result = '{"results":[{"code":200.0,"status":"Successfully removed all downtimes for object \'xyz.example.com\'."}]}'
-     stub_request(:post, "https://localhost:5665/v1/actions/remove-downtime").
+    stub_request(:post, "https://localhost:5665/v1/actions/remove-downtime").
       with(:body => '{"type":"Host","filter":"host.name==\"xyz.example.com\"","author":"Foreman","comment":"Downtime by Foreman"}').
       to_return(:status => 200, :body => icinga_result)
     @provider.remove_downtime_host('xyz.example.com', 'Foreman', 'Downtime by Foreman')


### PR DESCRIPTION
Adding Ruby v3 supports.

Requires:

- [x] https://github.com/theforeman/smart_proxy_monitoring/pull/30