### PR TITLE
Avoid changing hash during iteration

### DIFF
--- a/lib/smart_proxy_monitoring_icinga2/icinga2_result_uploader.rb
+++ b/lib/smart_proxy_monitoring_icinga2/icinga2_result_uploader.rb
@@ -80,10 +80,9 @@ module ::Proxy::Monitoring::Icinga2
     private
 
     def symbolize_keys_deep!(h)
-      h.each_key do |k|
-        ks    = k.to_sym
-        h[ks] = h.delete k
-        symbolize_keys_deep! h[ks] if h[ks].is_a? Hash
+      h.transform_keys!(&:to_sym)
+      h.each_value do |v|
+        symbolize_keys_deep!(v) if v.is_a?(Hash)
       end
     end
 


### PR DESCRIPTION
The old code failed with:

    can't add a new key into hash during iteration

The new code uses `transform_keys` to change all keys and then iterates all values. While this means it iterates twice, it should at least be safe.

Reported at: https://community.theforeman.org/t/foreman-proxy-monitoring-down-upgrading-foreman-from-3-10-to-3-11/38579/2